### PR TITLE
Avoid destroying all clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,16 @@ module.exports.createClient = (opts, cb) => {
     cb = onetime(cb);
     const clients = [];
     const errors = {};
+    let winner = null;
 
     opts.url.forEach(url => {
       const client = createClient(Object.assign({}, opts, {url}));
       clients.push(client);
 
       client.on("connect", () => {
-        const winner = client;
+        if (winner) return;
+
+        winner = client;
         cb(null, winner);
 
         // destroy other clients


### PR DESCRIPTION
For two ldap urls, the "connect" event is being sent twice and the second event callback is killing the winner client.

This PR should fix this.
